### PR TITLE
CT6-28: Implement admin order status update backend logic

### DIFF
--- a/backend/orders/serializers.py
+++ b/backend/orders/serializers.py
@@ -24,5 +24,6 @@ class OrderSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
             "delivered_at",
+            "items",
         ]
         read_only_fields = ["user", "created_at", "updated_at", "delivered_at"]

--- a/backend/orders/urls.py
+++ b/backend/orders/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import CheckoutView, OrderCancelView, OrderReturnView
+from .views import CheckoutView, OrderCancelView, OrderReturnView, admin_update_order_status
 
 urlpatterns = [
     path('checkout/', CheckoutView.as_view(), name='checkout'),
+    path("admin/update-status/<int:order_id>/", admin_update_order_status),
     path('<int:pk>/cancel/', OrderCancelView.as_view(), name='order-cancel'),
     path('<int:pk>/return/', OrderReturnView.as_view(), name='order-return'),
 ]


### PR DESCRIPTION
This PR implements the backend logic for the Admin Order Status Update feature.

- Added admin endpoint: PUT /api/orders/admin/update-status/<order_id>/
- Added permission control using IsAdminUser
- Added status validation based on STATUS_CHOICES
- Updated views.py with admin_update_order_status
- Updated serializers.py to expose items on orders
- Updated orders/urls.py to include the admin status update route


