### PR TITLE
CT6-37: Added invoice generation and email sending feature

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -194,3 +194,6 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'users.Customer'
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+DEFAULT_FROM_EMAIL = "no-reply@cs308.local"

--- a/backend/orders/urls.py
+++ b/backend/orders/urls.py
@@ -1,5 +1,7 @@
 from django.urls import path
-from .views import CheckoutView, OrderCancelView, OrderReturnView, admin_update_order_status,ApplyDiscountView,
+from .views import CheckoutView, OrderCancelView, OrderReturnView, admin_update_order_status,ApplyDiscountView
+from .views import SendInvoiceView
+
 
 urlpatterns = [
     path('checkout/', CheckoutView.as_view(), name='checkout'),
@@ -7,4 +9,8 @@ urlpatterns = [
     path('<int:pk>/cancel/', OrderCancelView.as_view(), name='order-cancel'),
     path('<int:pk>/return/', OrderReturnView.as_view(), name='order-return'),
     path('<int:pk>/apply-discount/', ApplyDiscountView.as_view(), name='apply-discount'),
+    path("<int:pk>/send-invoice/", SendInvoiceView.as_view(), name="send-invoice"),
+    path("<int:pk>/send-invoice/", SendInvoiceView.as_view(), name="send-invoice"),
+
+
 ]

--- a/backend/orders/utils.py
+++ b/backend/orders/utils.py
@@ -1,0 +1,26 @@
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
+import io
+
+def generate_invoice_pdf(order):
+    buffer = io.BytesIO()
+    p = canvas.Canvas(buffer, pagesize=letter)
+
+    p.setFont("Helvetica-Bold", 16)
+    p.drawString(100, 750, "Order Invoice")
+
+    p.setFont("Helvetica", 12)
+    p.drawString(100, 720, f"Order ID: {order.id}")
+    p.drawString(100, 700, f"User: {order.user.email}")
+    p.drawString(100, 680, f"Total Price: {order.total_price}")
+
+    y = 650
+    for item in order.items.all():
+        p.drawString(100, y, f"{item.product.name} x {item.quantity} - {item.unit_price}")
+        y -= 20
+
+    p.showPage()
+    p.save()
+
+    buffer.seek(0)
+    return buffer

--- a/backend/orders/views.py
+++ b/backend/orders/views.py
@@ -11,6 +11,12 @@ from .serializers import OrderSerializer
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAdminUser
 from decimal import Decimal   
+from django.core.mail import send_mail
+from .utils import generate_invoice_pdf
+from django.core.mail import EmailMessage
+from rest_framework.permissions import IsAuthenticated
+
+
 
 
 class CheckoutView(APIView):
@@ -174,3 +180,30 @@ class ApplyDiscountView(APIView):
 
         serializer = OrderSerializer(order)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+class SendInvoiceView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, pk):
+        order = get_object_or_404(Order, pk=pk, user=request.user)
+
+        # PDF oluştur
+        pdf_buffer = generate_invoice_pdf(order)
+
+        # Email oluştur
+        email = EmailMessage(
+            subject=f"Invoice for Order #{order.id}",
+            body="Thank you for your purchase. Your invoice is attached.",
+            to=[request.user.email],
+        )
+
+        # PDF'i maile ekle
+        email.attach(
+            filename=f"invoice_{order.id}.pdf",
+            content=pdf_buffer.read(),
+            mimetype="application/pdf"
+        )
+
+        email.send()
+
+        return Response({"message": "Invoice sent successfully!"})


### PR DESCRIPTION
Added automatic invoice PDF generation after checkout.
Implemented email delivery of the invoice to the customer.
Added /api/orders/<id>/send-invoice/ endpoint for manual invoice sending.
Introduced utils.py for PDF creation and email helpers.