### PR TITLE
CT6-55 – Checkout concurrency fix + regression coverage

### DIFF
--- a/backend/orders/tests.py
+++ b/backend/orders/tests.py
@@ -1,3 +1,75 @@
-from django.test import TestCase
+# backend/orders/tests.py
+from django.test import TransactionTestCase
+from django.contrib.auth import get_user_model
+from django.db import close_old_connections
+from threading import Thread, Barrier
+from rest_framework.test import APIClient
+from unittest.mock import patch
 
-# Create your tests here.
+from products.models import Product
+from orders.models import Order
+
+
+class CheckoutConcurrencyTest(TransactionTestCase):
+    # TransactionTestCase => gerçek transaction + concurrency için doğru sınıf
+    reset_sequences = True
+
+    def setUp(self):
+        User = get_user_model()
+        # create_user imzanız farklıysa burada patlayabilir:
+        # o durumda buraya hata mesajını at, signature'a göre düzeltirim.
+        self.user = User.objects.create_user(
+            username="concurrency_user",
+            email="concurrency_user@example.com",
+            password="pass12345"
+        )
+
+        self.product = Product.objects.create(
+            name="Test Product",
+            price="10.00",
+            stock=1,
+            warranty=12
+        )
+
+        self.url = "/api/orders/checkout/"
+
+    def _post_checkout(self, barrier, results, idx):
+        close_old_connections()  # thread başına ayrı DB connection
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+
+        payload = {
+            "items": [{"product_id": self.product.id, "quantity": 1}],
+            "shipping": {"name": "X", "address": "Y", "city": "Z", "phone": "000"}
+        }
+
+        barrier.wait()  # iki thread aynı anda başlasın
+        r = client.post(self.url, payload, format="json")
+        results[idx] = r.status_code
+
+    @patch("orders.views.send_order_confirmation_email", autospec=True)
+    def test_race_condition_on_stock(self, _mock_email):
+        """
+        Eğer kilit yoksa: 2 paralel checkout -> bazen 2 order oluşur / stok negatif olur.
+        Fix sonrası: 1 success, 1 fail; stok 0; order sayısı 1.
+        """
+        barrier = Barrier(2)
+        results = [None, None]
+
+        t1 = Thread(target=self._post_checkout, args=(barrier, results, 0))
+        t2 = Thread(target=self._post_checkout, args=(barrier, results, 1))
+
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        # FIX sonrası beklenti: 1 tane 201, 1 tane 409/400
+        self.product.refresh_from_db()
+
+        self.assertEqual(self.product.stock, 0, f"Stock should be 0, got {self.product.stock}")
+        self.assertEqual(Order.objects.count(), 1, f"Only 1 order should be created, got {Order.objects.count()}")
+
+        self.assertIn(201, results, f"Expected one 201, got {results}")
+        self.assertTrue(
+            any(code in (400, 409) for code in results),
+            f"Expected one 400/409, got {results}"
+        )

--- a/backend/orders/views.py
+++ b/backend/orders/views.py
@@ -120,33 +120,33 @@ class CheckoutView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
-        """
-        Accepts either:
-        - items array in the request body (authenticated user checkout)
-        - or uses authenticated user's server cart (CartItem).
-        """
         user = request.user
         items_data = request.data.get("items") or []
         shipping_data = request.data.get("shipping", {})
 
-        # If no items provided, fall back to server cart for authenticated users
         use_cart = not items_data and user is not None
 
         with transaction.atomic():
             if use_cart:
                 cart_items = CartItem.objects.filter(user=user).select_related("product")
                 if not cart_items.exists():
-                    return Response(
-                        {"error": "Your cart is empty."},
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
+                    return Response({"error": "Your cart is empty."}, status=status.HTTP_400_BAD_REQUEST)
 
-                # Validate stock
-                for item in cart_items:
-                    if item.product.stock < item.quantity:
+                req = {ci.product_id: ci.quantity for ci in cart_items}
+
+                locked = Product.objects.select_for_update().filter(id__in=req.keys())
+                locked_by_id = {p.id: p for p in locked}
+
+                missing = set(req.keys()) - set(locked_by_id.keys())
+                if missing:
+                    return Response({"error": "Product not found."}, status=status.HTTP_404_NOT_FOUND)
+
+                for pid, qty in req.items():
+                    p = locked_by_id[pid]
+                    if p.stock < qty:
                         return Response(
-                            {"error": f"Not enough stock for: {item.product.name}"},
-                            status=status.HTTP_400_BAD_REQUEST,
+                            {"error": f"Not enough stock for: {p.name}"},
+                            status=status.HTTP_409_CONFLICT,
                         )
 
                 order = Order.objects.create(
@@ -157,55 +157,64 @@ class CheckoutView(APIView):
                     shipping_city=shipping_data.get('city', ''),
                     shipping_phone=shipping_data.get('phone', '')
                 )
-                total = Decimal("0")
 
-                for item in cart_items:
+                total = Decimal("0")
+                touched_products = []
+
+                for ci in cart_items:
+                    p = locked_by_id[ci.product_id]
+
                     OrderItem.objects.create(
                         order=order,
-                        product=item.product,
-                        quantity=item.quantity,
-                        unit_price=item.product.price,
+                        product=p,
+                        quantity=ci.quantity,
+                        unit_price=p.price,
                     )
-                    total += item.product.price * item.quantity
 
-                    # decrement stock
-                    item.product.stock -= item.quantity
-                    item.product.save()
+                    total += p.price * ci.quantity
+                    p.stock -= ci.quantity
+                    touched_products.append(p)
+
+                if touched_products:
+                    Product.objects.bulk_update(touched_products, ["stock"])
 
                 order.total_price = total
                 order.save()
 
-                # clear cart
                 cart_items.delete()
 
-                # Send order confirmation email
-                try:
-                    send_order_confirmation_email(order)
-                except Exception as e:
-                    # Log error but don't fail the order creation
-                    print(f"Failed to send order confirmation email: {e}")
+                transaction.on_commit(lambda: send_order_confirmation_email(order))
 
                 serializer = OrderSerializer(order)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-            # Fallback: use provided items_data (guest checkout or client-provided payload)
-            normalized = []
+            req = {}
             for raw in items_data:
                 pid = raw.get("product_id") or raw.get("productId")
                 qty = int(raw.get("quantity") or raw.get("qty") or 1)
                 if not pid:
                     return Response({"error": "product_id is required"}, status=status.HTTP_400_BAD_REQUEST)
-                product = get_object_or_404(Product, pk=int(pid))
                 qty = max(1, qty)
-                if product.stock < qty:
-                    return Response(
-                        {"error": f"Not enough stock for: {product.name}"},
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
-                normalized.append((product, qty))
+                pid = int(pid)
+                req[pid] = req.get(pid, 0) + qty
 
-            if not normalized:
+            if not req:
                 return Response({"error": "Your cart is empty."}, status=status.HTTP_400_BAD_REQUEST)
+
+            locked = Product.objects.select_for_update().filter(id__in=req.keys())
+            locked_by_id = {p.id: p for p in locked}
+
+            missing = set(req.keys()) - set(locked_by_id.keys())
+            if missing:
+                return Response({"error": "Product not found."}, status=status.HTTP_404_NOT_FOUND)
+
+            for pid, qty in req.items():
+                p = locked_by_id[pid]
+                if p.stock < qty:
+                    return Response(
+                        {"error": f"Not enough stock for: {p.name}"},
+                        status=status.HTTP_409_CONFLICT,
+                    )
 
             order = Order.objects.create(
                 user=user,
@@ -215,28 +224,31 @@ class CheckoutView(APIView):
                 shipping_city=shipping_data.get('city', ''),
                 shipping_phone=shipping_data.get('phone', '')
             )
-            total = Decimal("0")
 
-            for product, qty in normalized:
+            total = Decimal("0")
+            touched_products = []
+
+            for pid, qty in req.items():
+                p = locked_by_id[pid]
+
                 OrderItem.objects.create(
                     order=order,
-                    product=product,
+                    product=p,
                     quantity=qty,
-                    unit_price=product.price,
+                    unit_price=p.price,
                 )
-                total += product.price * qty
-                product.stock -= qty
-                product.save()
+
+                total += p.price * qty
+                p.stock -= qty
+                touched_products.append(p)
+
+            if touched_products:
+                Product.objects.bulk_update(touched_products, ["stock"])
 
             order.total_price = total
             order.save()
 
-            # Send order confirmation email
-            try:
-                send_order_confirmation_email(order)
-            except Exception as e:
-                # Log error but don't fail the order creation
-                print(f"Failed to send order confirmation email: {e}")
+            transaction.on_commit(lambda: send_order_confirmation_email(order))
 
             serializer = OrderSerializer(order)
             return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
This PR addresses a race condition in the checkout flow where concurrent requests could oversell the same product (or create multiple orders for limited stock).

What changed
	•	Commit 1: Added a checkout concurrency regression test (backend/orders/tests.py) that fires two parallel checkout requests against a product with stock=1 and asserts:
	•	exactly one request succeeds (201),
	•	the other fails (400/409),
	•	final stock becomes 0,
	•	only one Order is created.
	•	Commit 2: Updated checkout implementation to be atomic and safe under concurrency by using transaction.atomic() + row-level locking (select_for_update()), and returning 409 Conflict when there is not enough stock.

How it was verified
	•	Manual Postman run using the same payload twice:
	•	First request: 201 Created (stock decremented)
	•	Second request: 409 Conflict with “Not enough stock …”
	•	The new regression test covers the same scenario to prevent future breakage.
